### PR TITLE
feat: add `php-cs-fixer.enableIgnoreEnv` option (PHP_CS_FIXER_IGNORE_ENV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If "1" and "2" above are not detected, the download feature will be executed (Th
 
 - `php-cs-fixer.enable`: Enable coc-php-cs-fixer extension, default: `true`
 - `php-cs-fixer.downloadMajorVersion`: Specify the major version of php-cs-fixer to download for the extension, valid option `[2, 3]`, default: `3`
+- `php-cs-fixer.enableIgnoreEnv`: Add the environment variable `PHP_CS_FIXER_IGNORE_ENV=1` and run php-cs-fixer, default: `false`
 - `php-cs-fixer.enableActionProvider`: Enable codeAction provider, default: `true`
 - `php-cs-fixer.enableFormatProvider`: Enable format provider, default: `false`
 - `php-cs-fixer.toolPath`: The path to the php-cs-fixer tool (Absolute path), default: `""`

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
           "description": "Specify the major version of php-cs-fixer to download for the extension",
           "scope": "window"
         },
+        "php-cs-fixer.enableIgnoreEnv": {
+          "type": "boolean",
+          "default": false,
+          "description": "Add the environment variable PHP_CS_FIXER_IGNORE_ENV=1 and run php-cs-fixer"
+        },
         "php-cs-fixer.enableActionProvider": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Close https://github.com/yaegassy/coc-php-cs-fixer/issues/3

Add the environment variable `PHP_CS_FIXER_IGNORE_ENV=1` and run php-cs-fixer, default: `false`

For example, currently php-cs-fixer is not fully support with PHP 8.1, so it will output an error and the formatting cannot be performed.

It is possible to force execution by adding an environment variable.