### PR TITLE
feat: add "php-cs-fixer.dryRunDiff" command feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Add the settings to `coc-settings.json`.
 ## Commands
 
 - `php-cs-fixer.fix`: Run php-cs-fixer fix
-- `php-cs-fixer.dryRunDiff`: Run php-cs-fixer fix with -`-dry-run` and `--diff` in a terminal window
+- `php-cs-fixer.dryRunDiff`: Run php-cs-fixer fix with `--dry-run` and `--diff` in a terminal window | [DEMO](https://github.com/yaegassy/coc-php-cs-fixer/pull/8)
 - `php-cs-fixer.pintFix`: Run pint
 - `php-cs-fixer.download`: Download php-cs-fixer
    - By default, the "v3" series will be downloaded. If you want to download "v2" series, please change the `php-cs-fixer.downloadMajorVersion` setting.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Add the settings to `coc-settings.json`.
 ## Commands
 
 - `php-cs-fixer.fix`: Run php-cs-fixer fix
+- `php-cs-fixer.dryRunDiff`: Run php-cs-fixer fix with -`-dry-run` and `--diff` in a terminal window
 - `php-cs-fixer.pintFix`: Run pint
 - `php-cs-fixer.download`: Download php-cs-fixer
    - By default, the "v3" series will be downloaded. If you want to download "v2" series, please change the `php-cs-fixer.downloadMajorVersion` setting.

--- a/package.json
+++ b/package.json
@@ -179,20 +179,24 @@
         "title": "Run php-cs-fixer fix"
       },
       {
-        "command": "php-cs-fixer.download",
-        "title": "Download php-cs-fixer"
-      },
-      {
-        "command": "php-cs-fixer.showOutput",
-        "title": "Show php-cs-fixer output channel"
+        "command": "php-cs-fixer.dryRunDiff",
+        "title": "Run php-cs-fixer fix with --dry-run and --diff in a terminal window"
       },
       {
         "command": "php-cs-fixer.pintFix",
         "title": "Run pint"
       },
       {
+        "command": "php-cs-fixer.download",
+        "title": "Download php-cs-fixer"
+      },
+      {
         "command": "php-cs-fixer.pintDownload",
         "title": "Download pint"
+      },
+      {
+        "command": "php-cs-fixer.showOutput",
+        "title": "Show php-cs-fixer output channel"
       }
     ]
   }

--- a/src/commands/pcfDryRunDiff.ts
+++ b/src/commands/pcfDryRunDiff.ts
@@ -1,0 +1,100 @@
+import { commands, ExtensionContext, Terminal, Uri, window, workspace } from 'coc.nvim';
+import { getPcfPath, isExistsFixerConfigFileFromProjectRoot, resolveConfigPath } from '../common';
+
+interface ProcessEnv {
+  [key: string]: string | undefined;
+}
+
+let terminal: Terminal | undefined;
+
+export function activate(context: ExtensionContext) {
+  context.subscriptions.push(commands.registerCommand('php-cs-fixer.dryRunDiff', pcfDryRunDiffCommand(context)));
+}
+
+async function runPcfDryRunDiff(context: ExtensionContext, filePath: string) {
+  const pcfBin = getPcfPath(context);
+
+  if (pcfBin) {
+    if (terminal) {
+      if (terminal.bufnr) {
+        await workspace.nvim.command(`bd! ${terminal.bufnr}`);
+      }
+      terminal.dispose();
+      terminal = undefined;
+    }
+
+    const extensionConfig = workspace.getConfiguration('php-cs-fixer');
+    const isUseCache = extensionConfig.get('useCache', false);
+    const isAllowRisky = extensionConfig.get('allowRisky', true);
+    const extensionFixerConfig = extensionConfig.get('config', '');
+    const fixerRules = extensionConfig.get('rules', '@PSR12');
+    const enableIgnoreEnv = extensionConfig.get<boolean>('enableIgnoreEnv', false);
+
+    const existsFixerConfigFile = isExistsFixerConfigFileFromProjectRoot();
+
+    const cwd = workspace.root;
+    let env: ProcessEnv | undefined = undefined;
+    if (enableIgnoreEnv) {
+      env = {
+        ...process.env,
+        PHP_CS_FIXER_IGNORE_ENV: '1',
+      };
+    }
+
+    terminal = await window.createTerminal({ name: 'pcf-dry-run-diff', cwd, env });
+
+    const args: string[] = [];
+
+    if (extensionFixerConfig) {
+      const resolvedFixerConfig = resolveConfigPath(extensionFixerConfig, cwd);
+      args.push('--config=' + resolvedFixerConfig);
+    } else if (existsFixerConfigFile) {
+      // If the pint.json config file exists for the project root.
+      //
+      // ...noop
+    } else {
+      if (!isUseCache) {
+        args.push('--using-cache=no');
+      }
+      if (isAllowRisky) {
+        args.push('--allow-risky=yes');
+      }
+      if (fixerRules) {
+        args.push(`--rules='${fixerRules}'`);
+      }
+    }
+
+    args.push('fix');
+    args.push(filePath);
+    args.push('--dry-run');
+    args.push('--diff');
+
+    terminal.sendText(`${pcfBin} ${args.join(' ')}`);
+
+    const enableSplitRight = workspace
+      .getConfiguration('php-cs-fixer')
+      .get<boolean>('terminal.enableSplitRight', false);
+
+    if (enableSplitRight) terminal.hide();
+    await workspace.nvim.command('stopinsert');
+    if (enableSplitRight) {
+      await workspace.nvim.command(`vert bel sb ${terminal.bufnr}`);
+      await workspace.nvim.command(`wincmd p`);
+    }
+  } else {
+    return window.showErrorMessage('php-cs-fixer not found!');
+  }
+}
+
+export function pcfDryRunDiffCommand(context: ExtensionContext) {
+  return async () => {
+    const { document } = await workspace.getCurrentState();
+    const filePath = Uri.parse(document.uri).fsPath;
+
+    if (document.languageId !== 'php') {
+      return window.showErrorMessage('This file is not a PHP file!');
+    }
+
+    runPcfDryRunDiff(context, filePath);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as pcfFixCodeActionFeature from './actions/pcfFix';
 import * as pintFixCodeActionFeature from './actions/pintFix';
 import * as pcfDownloadCommandFeature from './commands/pcfDownload';
 import * as pcfFixCommandFeature from './commands/pcfFix';
+import * as pcfDryRunDiffCommandFeature from './commands/pcfDryRunDiff';
 import * as pintDonwloadCommandFeature from './commands/pintDownload';
 import * as pintFixCommandFeature from './commands/pintFix';
 import * as showOutputCommandFeature from './commands/showOutput';
@@ -49,6 +50,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   if (activateTool === 'php-cs-fixer') {
     pcfFixCommandFeature.activate(context, outputChannel);
+    pcfDryRunDiffCommandFeature.activate(context);
     pcfFixDocumentFormatFeature.activate(context, outputChannel);
     pcfFixCodeActionFeature.activate(context);
   } else if (activateTool === 'pint') {


### PR DESCRIPTION
## Description

Add the options `--dry-run` and `--diff` to the `php-cs-fixer fix` and run it in a "terminal" window.

The direction in which the terminal window is split can be changed using the `php-cs-fixer.terminal.enableSplitRight` setting.

## DEMO(mp4)

> let g:coc_terminal_height = 15

https://user-images.githubusercontent.com/188642/177456687-f9f65231-9e1b-4a98-a55c-f696f307ade8.mp4
