### PR TITLE
feat: add "php-cs-fixer.pintTest" command feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Add the settings to `coc-settings.json`.
 - `php-cs-fixer.fix`: Run php-cs-fixer fix
 - `php-cs-fixer.dryRunDiff`: Run php-cs-fixer fix with `--dry-run` and `--diff` in a terminal window | [DEMO](https://github.com/yaegassy/coc-php-cs-fixer/pull/8)
 - `php-cs-fixer.pintFix`: Run pint
-- `php-cs-fixer.pintTest`: Run pint with `--test` in a terminal window
+- `php-cs-fixer.pintTest`: Run pint with `--test` in a terminal window | [DEMO](https://github.com/yaegassy/coc-php-cs-fixer/pull/9#issue-1295053515)
 - `php-cs-fixer.download`: Download php-cs-fixer
    - By default, the "v3" series will be downloaded. If you want to download "v2" series, please change the `php-cs-fixer.downloadMajorVersion` setting.
 - `php-cs-fixer.pintDownload`: Download pint

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Add the settings to `coc-settings.json`.
 - `php-cs-fixer.fix`: Run php-cs-fixer fix
 - `php-cs-fixer.dryRunDiff`: Run php-cs-fixer fix with `--dry-run` and `--diff` in a terminal window | [DEMO](https://github.com/yaegassy/coc-php-cs-fixer/pull/8)
 - `php-cs-fixer.pintFix`: Run pint
+- `php-cs-fixer.pintTest`: Run pint with `--test` in a terminal window
 - `php-cs-fixer.download`: Download php-cs-fixer
    - By default, the "v3" series will be downloaded. If you want to download "v2" series, please change the `php-cs-fixer.downloadMajorVersion` setting.
 - `php-cs-fixer.pintDownload`: Download pint

--- a/package.json
+++ b/package.json
@@ -187,6 +187,10 @@
         "title": "Run pint"
       },
       {
+        "command": "php-cs-fixer.pintTest",
+        "title": "Run pint with --test in a terminal window"
+      },
+      {
         "command": "php-cs-fixer.download",
         "title": "Download php-cs-fixer"
       },

--- a/src/commands/pintTest.ts
+++ b/src/commands/pintTest.ts
@@ -1,0 +1,77 @@
+import { commands, ExtensionContext, Terminal, Uri, window, workspace } from 'coc.nvim';
+import { getPintPath, resolveConfigPath, isExistsPintConfigFileFromProjectRoot } from '../common';
+
+let terminal: Terminal | undefined;
+
+export function activate(context: ExtensionContext) {
+  context.subscriptions.push(commands.registerCommand('php-cs-fixer.pintTest', pintTestCommand(context)));
+}
+
+async function runPintTest(context: ExtensionContext, filePath: string) {
+  const pintBin = getPintPath(context);
+
+  if (pintBin) {
+    if (terminal) {
+      if (terminal.bufnr) {
+        await workspace.nvim.command(`bd! ${terminal.bufnr}`);
+      }
+      terminal.dispose();
+      terminal = undefined;
+    }
+
+    const cwd = workspace.root;
+    terminal = await window.createTerminal({ name: 'pint-test', cwd });
+
+    const args: string[] = [];
+
+    const extensionConfig = workspace.getConfiguration('php-cs-fixer');
+    const extensionPintConfig = extensionConfig.get('pint.config', '');
+    const preset = extensionConfig.get('pint.preset', 'laravel');
+
+    const existsPintConfigFile = isExistsPintConfigFileFromProjectRoot();
+
+    if (extensionPintConfig) {
+      const resolvedPintConfig = resolveConfigPath(extensionPintConfig, cwd);
+      args.push('--config=' + resolvedPintConfig);
+    } else if (existsPintConfigFile) {
+      // If the pint.json config file exists for the project root.
+      //
+      // ...noop
+    } else {
+      if (preset) {
+        args.push(`--preset=${preset}`);
+      }
+    }
+
+    args.push('--test');
+    args.push(`${filePath}`);
+
+    terminal.sendText(`${pintBin} ${args.join(' ')}`);
+
+    const enableSplitRight = workspace
+      .getConfiguration('php-cs-fixer')
+      .get<boolean>('terminal.enableSplitRight', false);
+
+    if (enableSplitRight) terminal.hide();
+    await workspace.nvim.command('stopinsert');
+    if (enableSplitRight) {
+      await workspace.nvim.command(`vert bel sb ${terminal.bufnr}`);
+      await workspace.nvim.command(`wincmd p`);
+    }
+  } else {
+    return window.showErrorMessage('pint not found!');
+  }
+}
+
+export function pintTestCommand(context: ExtensionContext) {
+  return async () => {
+    const { document } = await workspace.getCurrentState();
+    const filePath = Uri.parse(document.uri).fsPath;
+
+    if (document.languageId !== 'php') {
+      return window.showErrorMessage('This file is not a PHP file!');
+    }
+
+    runPintTest(context, filePath);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,11 @@ import fs from 'fs';
 import * as pcfFixCodeActionFeature from './actions/pcfFix';
 import * as pintFixCodeActionFeature from './actions/pintFix';
 import * as pcfDownloadCommandFeature from './commands/pcfDownload';
-import * as pcfFixCommandFeature from './commands/pcfFix';
 import * as pcfDryRunDiffCommandFeature from './commands/pcfDryRunDiff';
+import * as pcfFixCommandFeature from './commands/pcfFix';
 import * as pintDonwloadCommandFeature from './commands/pintDownload';
 import * as pintFixCommandFeature from './commands/pintFix';
+import * as pintTestCommandFeature from './commands/pintTest';
 import * as showOutputCommandFeature from './commands/showOutput';
 import { getPcfPath, getPintPath } from './common';
 import * as pcfFixDocumentFormatFeature from './documentFormats/pcfFix';
@@ -55,6 +56,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     pcfFixCodeActionFeature.activate(context);
   } else if (activateTool === 'pint') {
     pintFixCommandFeature.activate(context, outputChannel);
+    pintTestCommandFeature.activate(context);
     pintFixDocumentFormatFeature.activate(context, outputChannel);
     pintFixCodeActionFeature.activate(context);
   }


### PR DESCRIPTION
## Description

Add the options `--test` to the `pint` and run it in a "terminal" window.

The direction in which the terminal window is split can be changed using the `php-cs-fixer.terminal.enableSplitRight` setting.

## DEMO(mp4)

> let g:coc_terminal_height = 15

https://user-images.githubusercontent.com/188642/177458615-ca5e8d7c-fe6d-4b3e-8d42-02a930534140.mp4
