### PR TITLE
fix(schema): fix PHP assoc. array -> JS object type issues

### DIFF
--- a/schemas/pint-schema.json
+++ b/schemas/pint-schema.json
@@ -118,7 +118,7 @@
             "operators": {
               "description": "Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `=`, `*`, `/`, `%`, `<`, `>`, `|`, `^`, `+`, `-`, `&`, `&=`, `&&`, `||`, `.=`, `/=`, `=>`, `==`, `>=`, `===`, `!=`, `<>`, `!==`, `<=`, `and`, `or`, `xor`, `-=`, `%=`, `*=`, `|=`, `+=`, `<<`, `<<=`, `>>`, `>>=`, `^=`, `**`, `**=`, `<=>`, `??`, `??=`",
               "default": {},
-              "type": "array"
+              "type": "object"
             }
           }
         },
@@ -263,7 +263,7 @@
                 "trait_import": "none",
                 "case": "none"
               },
-              "type": "array"
+              "type": "object"
             }
           }
         },
@@ -1290,7 +1290,7 @@
             "replacements": {
               "description": "A map of tags to replace.",
               "default": {},
-              "type": "array"
+              "type": "object"
             }
           }
         },
@@ -2535,8 +2535,8 @@
             },
             "methods": {
               "description": "Dictionary of `method` => `call_type` values that differ from the default strategy.",
-              "default": [],
-              "type": "array"
+              "default": {},
+              "type": "object"
             }
           }
         },
@@ -2690,7 +2690,7 @@
                 "type": "var",
                 "link": "see"
               },
-              "type": "array"
+              "type": "object"
             }
           }
         },
@@ -2768,7 +2768,7 @@
                 "$static": "static",
                 "@static": "static"
               },
-              "type": "array"
+              "type": "object"
             }
           }
         },
@@ -2884,7 +2884,7 @@
                 "var": "annotation",
                 "version": "annotation"
               },
-              "type": "array"
+              "type": "object"
             }
           }
         },
@@ -3032,7 +3032,7 @@
                 "rand": "mt_rand",
                 "srand": "mt_srand"
               },
-              "type": "array"
+              "type": "object"
             }
           }
         },


### PR DESCRIPTION
Hi there! Just fixing a couple of issues in the schema file that were likely missed when the original author converted the schema from PHP to JSON. A couple of rule definitions were incorrectly typed as arrays when they should have been objects.

An example from the upstream source of the schema file:
https://github.com/open-southeners/vscode-laravel-pint/issues/40

CC: @d8vjork Since you're assigned to the above issue. :slightly_smiling_face: 